### PR TITLE
Add pytest suite and CI for signin automation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main", "master", "develop"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run test suite
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ python -m src.signin
 3. 若 systemd 没有触发，使用 `systemctl status anyrouter.timer` 查看状态，并确认 `TZ` 一致；
 4. 当页面元素改动时，更新 `config.toml` 中 `[selectors]`，可使用多策略定位（CSS / text / role）。
 
+## 测试与质量保证
+
+项目附带了覆盖配置解析、状态判定、邮件通知以及签到主流程的 pytest 测试套件，并在 GitHub Actions（`.github/workflows/tests.yml`）中默认运行。开发与部署前可通过以下命令本地验证：
+
+```bash
+pytest
+```
+
+如需在 CI 之外执行，可于虚拟环境中安装 `pytest`（`pip install pytest`）后运行上述命令。
+
 ## 安全提示
 
 * `config.toml` 中的 SMTP 凭据应限制权限（推荐 600）；

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Shared pytest fixtures and Playwright test doubles."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+if "playwright" not in sys.modules:
+    sys.modules["playwright"] = types.ModuleType("playwright")
+
+sync_api = types.ModuleType("playwright.sync_api")
+
+
+class DummyTimeoutError(Exception):
+    """Replacement for Playwright's TimeoutError used during tests."""
+
+
+def _unavailable_sync_playwright(*args, **kwargs):  # pragma: no cover - guardrail
+    raise RuntimeError("sync_playwright is not available in the test doubles")
+
+
+def _setup_sync_api_module() -> None:
+    sync_api.TimeoutError = DummyTimeoutError
+    sync_api.Page = object  # type: ignore[attr-defined]
+    sync_api.sync_playwright = _unavailable_sync_playwright
+    sys.modules["playwright.sync_api"] = sync_api
+
+
+_setup_sync_api_module()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.config import (
+    Config,
+    load_config,
+)
+
+
+def write_config(tmp_path: Path) -> Path:
+    content = """
+timezone = "America/New_York"
+
+[notify]
+enable_email = true
+success_email_once_per_day = true
+email_on_failure_always = false
+
+  [notify.smtp]
+  host = "smtp.example.com"
+  port = 587
+  use_ssl = false
+  use_starttls = true
+  username = "bot"
+  password = "secret"
+  from = "bot@example.com"
+  to = ["ops@example.com", "alerts@example.com"]
+
+[run]
+max_retries = 5
+retry_backoff_seconds = [1.5, 3.0, 6.0]
+history_limit = 50
+screenshot_on_failure = false
+
+[selectors]
+login_required = ["#login"]
+login_confirmed = ["#logged-in"]
+checkin_triggers = ["button.checkin"]
+success_indicators = [".alert-success"]
+already_checked = [".already"]
+
+[site]
+base_url = "https://example.com"
+checkin_url = "https://example.com/checkin"
+
+[logging]
+log_file = "logs/signin.jsonl"
+"""
+    path = tmp_path / "config.toml"
+    path.write_text(content)
+    return path
+
+
+def test_load_config_expands_paths(tmp_path: Path) -> None:
+    path = write_config(tmp_path)
+    config = load_config(path)
+    assert isinstance(config, Config)
+    assert config.project_root == tmp_path.resolve()
+    assert config.data_dir == tmp_path.resolve() / "data"
+    assert config.history_file == config.data_dir / "history.csv"
+    assert config.screenshots_dir == tmp_path.resolve() / "screenshots"
+    assert config.logging.log_file == tmp_path.resolve() / "logs" / "signin.jsonl"
+    assert config.notify.smtp is not None
+    assert config.notify.smtp.port == 587
+    assert config.notify.smtp.use_starttls is True
+    assert config.notify.smtp.recipients == ("ops@example.com", "alerts@example.com")
+    assert config.run.retry_backoff_seconds == (1.5, 3.0, 6.0)
+    assert config.selectors.login_required == ("#login",)
+
+
+def test_load_config_missing_file_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.toml"
+    with pytest.raises(FileNotFoundError):
+        load_config(missing)

--- a/tests/test_notifier_email.py
+++ b/tests/test_notifier_email.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from email.message import EmailMessage
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from src.config import (
+    Config,
+    LoggingConfig,
+    NotifyConfig,
+    RunConfig,
+    ScheduleConfig,
+    SelectorConfig,
+    SiteConfig,
+    SMTPConfig,
+)
+from src.notifier_email import EmailNotifier
+
+
+@pytest.fixture
+def config_with_email(tmp_path: Path) -> Config:
+    smtp = SMTPConfig(
+        host="smtp.example.com",
+        port=465,
+        use_ssl=True,
+        username="bot",
+        password="secret",
+        sender="bot@example.com",
+        recipients=("ops@example.com",),
+    )
+    return Config(
+        timezone="UTC",
+        schedule=ScheduleConfig(),
+        notify=NotifyConfig(enable_email=True, smtp=smtp),
+        run=RunConfig(),
+        selectors=SelectorConfig(),
+        site=SiteConfig(base_url="https://example.com", checkin_url="https://example.com/checkin"),
+        logging=LoggingConfig(log_file=tmp_path / "logs.jsonl"),
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        history_file=tmp_path / "data" / "history.csv",
+        screenshots_dir=tmp_path / "screenshots",
+        userdata_dir=tmp_path / "userdata",
+        meta_dir=tmp_path / "meta",
+    )
+
+
+class SendRecorder:
+    def __init__(self) -> None:
+        self.sent: List[EmailMessage] = []
+
+    def __call__(self, message: EmailMessage) -> None:
+        self.sent.append(message)
+
+
+def test_send_success_dispatches_and_records(config_with_email, monkeypatch) -> None:
+    notifier = EmailNotifier(config_with_email, tz=None)
+
+    monkeypatch.setattr("src.notifier_email.should_send_success_email", lambda *_: True)
+    recorded: List[Path] = []
+    monkeypatch.setattr("src.notifier_email.record_success_email_sent", lambda meta_dir, now: recorded.append(meta_dir))
+    sender = SendRecorder()
+    monkeypatch.setattr(EmailNotifier, "_send", lambda self, message: sender(message))
+
+    result = notifier.send_success("Subject", "Body")
+
+    assert result is True
+    assert len(sender.sent) == 1
+    message = sender.sent[0]
+    assert message["Subject"] == "Subject"
+    assert "ops@example.com" in message["To"]
+    assert recorded == [config_with_email.meta_dir]
+
+
+def test_send_success_skips_when_disabled(config_with_email) -> None:
+    notifier = EmailNotifier(config_with_email, tz=None)
+    notifier._config.notify.enable_email = False
+    assert notifier.send_success("Subject", "Body") is False
+
+
+def test_send_success_respects_daily_limit(config_with_email, monkeypatch) -> None:
+    notifier = EmailNotifier(config_with_email, tz=None)
+    monkeypatch.setattr("src.notifier_email.should_send_success_email", lambda *_: False)
+    monkeypatch.setattr(EmailNotifier, "_send", lambda self, message: (_ for _ in ()).throw(RuntimeError("should not send")))
+    assert notifier.send_success("Subject", "Body") is False
+
+
+def test_send_failure_with_attachments(config_with_email, tmp_path, monkeypatch) -> None:
+    notifier = EmailNotifier(config_with_email, tz=None)
+    attachment = tmp_path / "failure.png"
+    attachment.write_bytes(b"content")
+
+    sender = SendRecorder()
+    monkeypatch.setattr(EmailNotifier, "_send", lambda self, message: sender(message))
+
+    result = notifier.send_failure("Subject", "Body", attachments=[attachment])
+
+    assert result is True
+    assert len(sender.sent) == 1
+    message = sender.sent[0]
+    attachments = list(message.iter_attachments())
+    assert len(attachments) == 1
+    assert attachments[0].get_filename() == "failure.png"
+
+
+def test_send_failure_skips_when_disabled(config_with_email) -> None:
+    notifier = EmailNotifier(config_with_email, tz=None)
+    notifier._config.notify.email_on_failure_always = False
+    assert notifier.send_failure("Subject", "Body") is False

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from src.config import (
+    Config,
+    LoggingConfig,
+    NotifyConfig,
+    RunConfig,
+    ScheduleConfig,
+    SelectorConfig,
+    SiteConfig,
+    SMTPConfig,
+)
+from src.signin import CheckInOutcome, SignInError, main
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.infos: List[tuple[str, Optional[dict]]] = []
+        self.errors: List[tuple[str, Optional[dict]]] = []
+
+    def info(self, message: str, extra: Optional[dict] = None) -> None:
+        self.infos.append((message, extra))
+
+    def error(self, message: str, extra: Optional[dict] = None) -> None:
+        self.errors.append((message, extra))
+
+
+class NotifierStub:
+    def __init__(self) -> None:
+        self.success_calls: List[tuple[str, str]] = []
+        self.failure_calls: List[tuple[str, str, Optional[List[Path]]]] = []
+        self.config: Optional[Config] = None
+
+    def send_success(self, subject: str, body: str) -> bool:
+        self.success_calls.append((subject, body))
+        return True
+
+    def send_failure(self, subject: str, body: str, attachments: Optional[List[Path]] = None) -> bool:
+        self.failure_calls.append((subject, body, attachments))
+        return True
+
+
+@pytest.fixture
+def base_config(tmp_path: Path) -> Config:
+    smtp = SMTPConfig(
+        host="smtp.example.com",
+        port=465,
+        use_ssl=True,
+        recipients=("ops@example.com",),
+    )
+    return Config(
+        timezone="UTC",
+        schedule=ScheduleConfig(),
+        notify=NotifyConfig(enable_email=True, smtp=smtp),
+        run=RunConfig(max_retries=3, retry_backoff_seconds=(2.5, 5.0, 10.0)),
+        selectors=SelectorConfig(),
+        site=SiteConfig(base_url="https://example.com", checkin_url="https://example.com/checkin"),
+        logging=LoggingConfig(log_file=tmp_path / "logs.jsonl"),
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        history_file=tmp_path / "data" / "history.csv",
+        screenshots_dir=tmp_path / "screenshots",
+        userdata_dir=tmp_path / "userdata",
+        meta_dir=tmp_path / "meta",
+    )
+
+
+@pytest.fixture
+def notifier_stub(monkeypatch) -> NotifierStub:
+    stub = NotifierStub()
+
+    def factory(config: Config, tz) -> NotifierStub:
+        stub.config = config
+        return stub
+
+    monkeypatch.setattr("src.signin.EmailNotifier", factory)
+    return stub
+
+
+@pytest.fixture
+def dummy_logger(monkeypatch) -> DummyLogger:
+    logger = DummyLogger()
+    monkeypatch.setattr("src.signin.setup_logging", lambda config, run_id: logger)
+    return logger
+
+
+@pytest.fixture
+def deterministic_run(monkeypatch):
+    monkeypatch.setattr("src.signin.generate_run_id", lambda: "run-123")
+
+
+def configure_time(monkeypatch, timestamps: List[datetime]) -> None:
+    iterator = iter(timestamps)
+    monkeypatch.setattr("src.signin.now_tz", lambda tz: next(iterator))
+
+
+def test_main_success_flow(tmp_path, base_config, notifier_stub, dummy_logger, deterministic_run, monkeypatch) -> None:
+    config = base_config
+    config.notify.success_email_once_per_day = True
+
+    monkeypatch.setattr("src.signin.load_config", lambda: config)
+    monkeypatch.setattr("src.signin.ensure_data_tree", lambda *args, **kwargs: None)
+
+    configure_time(
+        monkeypatch,
+        [
+            datetime(2024, 1, 1, 7, 0, tzinfo=ZoneInfo("UTC")),
+            datetime(2024, 1, 1, 7, 0, 5, tzinfo=ZoneInfo("UTC")),
+        ],
+    )
+
+    outcome = CheckInOutcome(status="CHECKIN_OK", notes="done", url="https://example.com/checkin")
+    monkeypatch.setattr("src.signin._attempt_checkin", lambda *args, **kwargs: outcome)
+
+    history_records: List[List[str]] = []
+    monkeypatch.setattr(
+        "src.signin.append_history_entry",
+        lambda path, limit, row: history_records.append(row),
+    )
+
+    exit_code = main()
+
+    assert exit_code == 0
+    assert len(history_records) == 1
+    assert history_records[0][3] == "CHECKIN_OK"
+    assert len(notifier_stub.success_calls) == 1
+    subject, body = notifier_stub.success_calls[0]
+    assert subject.startswith("[AnyRouter][OK]")
+    assert "Run ID: run-123" in body
+    assert not notifier_stub.failure_calls
+
+
+def test_main_retry_and_failure_flow(tmp_path, base_config, notifier_stub, dummy_logger, deterministic_run, monkeypatch) -> None:
+    config = base_config
+    config.notify.email_on_failure_always = True
+    monkeypatch.setattr("src.signin.load_config", lambda: config)
+    monkeypatch.setattr("src.signin.ensure_data_tree", lambda *args, **kwargs: None)
+
+    configure_time(
+        monkeypatch,
+        [
+            datetime(2024, 1, 1, 7, 0, tzinfo=ZoneInfo("UTC")),
+            datetime(2024, 1, 1, 7, 0, 30, tzinfo=ZoneInfo("UTC")),
+        ],
+    )
+
+    screenshot_path = tmp_path / "screenshots" / "failure.png"
+    screenshot_path.parent.mkdir(parents=True, exist_ok=True)
+    screenshot_path.write_text("capture")
+
+    attempts = {"count": 0}
+
+    def attempt_stub(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            error = SignInError("TEMP", "temporary failure")
+            error.retryable = True
+            error.screenshot_path = str(screenshot_path)
+            raise error
+        error = SignInError("FINAL", "final failure", retryable=False)
+        error.screenshot_path = str(screenshot_path)
+        raise error
+
+    monkeypatch.setattr("src.signin._attempt_checkin", attempt_stub)
+
+    sleeps: List[float] = []
+
+    class SleepModule:
+        @staticmethod
+        def sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+    monkeypatch.setattr("src.signin.time", SleepModule)
+
+    history_records: List[List[str]] = []
+    monkeypatch.setattr(
+        "src.signin.append_history_entry",
+        lambda path, limit, row: history_records.append(row),
+    )
+
+    exit_code = main()
+
+    assert exit_code == 1
+    assert attempts["count"] == 2
+    assert sleeps == [2.5]
+    assert len(history_records) == 1
+    assert history_records[0][3] == "CHECKIN_FAIL"
+    assert history_records[0][4] == "FINAL"
+    assert len(notifier_stub.failure_calls) == 1
+    failure_subject, failure_body, attachments = notifier_stub.failure_calls[0]
+    assert "FINAL" in failure_subject
+    assert attachments and attachments[0] == Path(screenshot_path)
+    assert notifier_stub.success_calls == []

--- a/tests/test_state_check.py
+++ b/tests/test_state_check.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Callable, Dict, Optional
+
+import pytest
+
+from src.config import (
+    Config,
+    LoggingConfig,
+    NotifyConfig,
+    RunConfig,
+    ScheduleConfig,
+    SelectorConfig,
+    SiteConfig,
+    SMTPConfig,
+)
+from src.state_check import (
+    PlaywrightTimeoutError,
+    ensure_logged_in,
+    evaluate_checkin_state,
+    perform_checkin,
+)
+from src.utils import CheckInOutcome, SignInError
+
+
+class LocatorStub:
+    def __init__(self, behavior: Dict[str, Callable]):
+        self._behavior = behavior
+        self.first = self
+
+    def wait_for(self, *, state: str, timeout: int) -> None:
+        func: Optional[Callable] = self._behavior.get("wait_for")
+        if func is None:
+            raise PlaywrightTimeoutError("timeout")
+        func(state=state, timeout=timeout)
+
+    def click(self, *, timeout: int) -> None:
+        func: Optional[Callable] = self._behavior.get("click")
+        if func is None:
+            raise PlaywrightTimeoutError("click timeout")
+        func(timeout=timeout)
+
+
+class PageStub:
+    def __init__(self, behaviors: Dict[str, Dict[str, Callable]], url: str = "https://example.com") -> None:
+        self._behaviors = behaviors
+        self.url = url
+
+    def locator(self, selector: str) -> LocatorStub:
+        return LocatorStub(self._behaviors.get(selector, {}))
+
+
+@pytest.fixture
+def base_config(tmp_path):
+    smtp = SMTPConfig(
+        host="smtp.example.com",
+        port=465,
+        use_ssl=True,
+        recipients=("ops@example.com",),
+    )
+    config = Config(
+        timezone="UTC",
+        schedule=ScheduleConfig(),
+        notify=NotifyConfig(enable_email=True, smtp=smtp),
+        run=RunConfig(action_timeout_ms=1000),
+        selectors=SelectorConfig(
+            login_required=("#login",),
+            login_confirmed=("#ok",),
+            checkin_triggers=("button.checkin",),
+            success_indicators=(".success",),
+            already_checked=(".already",),
+        ),
+        site=SiteConfig(base_url="https://example.com", checkin_url="https://example.com/checkin"),
+        logging=LoggingConfig(log_file=tmp_path / "log.jsonl"),
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        history_file=tmp_path / "data" / "history.csv",
+        screenshots_dir=tmp_path / "screenshots",
+        userdata_dir=tmp_path / "userdata",
+        meta_dir=tmp_path / "meta",
+    )
+    return config
+
+
+def test_ensure_logged_in_requires_reauthentication(base_config):
+    page = PageStub({"#login": {"wait_for": lambda **_: None}})
+    with pytest.raises(SignInError) as exc:
+        ensure_logged_in(page, base_config)
+    assert exc.value.error_code == "NEED_AUTH"
+
+
+def test_ensure_logged_in_validates_confirmation(base_config):
+    page = PageStub({"#ok": {"wait_for": lambda **_: None}})
+    ensure_logged_in(page, base_config)
+
+
+def test_ensure_logged_in_raises_when_confirmation_missing(base_config):
+    page = PageStub({})
+    with pytest.raises(SignInError) as exc:
+        ensure_logged_in(page, base_config)
+    assert exc.value.error_code == "NEED_AUTH"
+
+
+def test_evaluate_checkin_state_reports_already_checked(base_config):
+    page = PageStub({".already": {"wait_for": lambda **_: None}})
+    outcome = evaluate_checkin_state(page, base_config)
+    assert isinstance(outcome, CheckInOutcome)
+    assert outcome.status == "CHECKIN_ALREADY"
+
+
+def test_perform_checkin_success(base_config):
+    behaviors = {
+        "button.checkin": {
+            "wait_for": lambda **_: None,
+            "click": lambda **_: None,
+        },
+        ".success": {"wait_for": lambda **_: None},
+    }
+    page = PageStub(behaviors)
+    outcome = perform_checkin(page, base_config)
+    assert outcome.status == "CHECKIN_OK"
+
+
+def test_perform_checkin_detects_already_checked_after_click(base_config):
+    behaviors = {
+        "button.checkin": {
+            "wait_for": lambda **_: None,
+            "click": lambda **_: None,
+        },
+        ".success": {},
+        ".already": {"wait_for": lambda **_: None},
+    }
+    page = PageStub(behaviors)
+    outcome = perform_checkin(page, base_config)
+    assert outcome.status == "CHECKIN_ALREADY"
+
+
+def test_perform_checkin_raises_when_trigger_missing(base_config):
+    config = replace(base_config, selectors=replace(base_config.selectors, checkin_triggers=(".missing",)))
+    page = PageStub({})
+    with pytest.raises(SignInError) as exc:
+        perform_checkin(page, config)
+    assert exc.value.error_code == "SELECTOR_CHANGED"
+
+
+def test_perform_checkin_raises_when_no_success_indicators(base_config):
+    config = replace(
+        base_config,
+        selectors=replace(
+            base_config.selectors,
+            success_indicators=(".success",),
+            already_checked=(),
+        ),
+    )
+    behaviors = {
+        "button.checkin": {
+            "wait_for": lambda **_: None,
+            "click": lambda **_: None,
+        },
+        ".success": {},
+    }
+    page = PageStub(behaviors)
+    with pytest.raises(SignInError) as exc:
+        perform_checkin(page, config)
+    assert exc.value.error_code == "UNKNOWN"


### PR DESCRIPTION
## Summary
- add pytest unit coverage for configuration loading, state detection, and email notifier behaviour
- introduce integration-style signin tests validating retries, history logging, and notification hooks
- stub Playwright imports for tests, document the workflow, and wire GitHub Actions with pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c19a1554832192dcf5040198cf56