### PR TITLE
Improve Playwright startup performance and locale handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ systemd/anyrouter.*     # systemd service + timer
 4. 根据实际账号信息编辑 `config.toml`：
    * 更新 SMTP 主机、账号、收件人；
    * 如果站点文案/选择器有变化，调整 `[selectors]` 中的策略；
-   * 根据需求修改重试、超时与调度时间。
+   * 根据需求修改重试、超时与调度时间；
+   * `run.browser_locale` 默认强制英文界面并附带优化后的 Chromium 启动参数，如需自定义语言可同时调整 `run.accept_language` 与 `run.chromium_launch_args`。
 
 ## 首次授权（GitHub OAuth）
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Core runtime dependencies
+playwright>=1.45
+# ``tomli`` provides ``tomllib`` for Python versions prior to 3.11
+tomli>=2.0.1; python_version < "3.11"
+tzdata>=2023.3
+
+# Tooling / tests
+pytest>=8.0

--- a/src/authorize.py
+++ b/src/authorize.py
@@ -5,6 +5,7 @@ import sys
 
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError, sync_playwright
 
+from .browser import launch_user_context
 from .config import load_config
 from .logging_setup import setup_logging
 from .utils import (
@@ -35,13 +36,8 @@ def main() -> int:
     context = None
     try:
         with sync_playwright() as p:
-            context = p.chromium.launch_persistent_context(
-                user_data_dir=str(config.userdata_dir),
-                headless=False,
-            )
+            context = launch_user_context(p, config, headless=False)
             page = context.new_page()
-            page.set_default_navigation_timeout(config.run.nav_timeout_ms)
-            page.set_default_timeout(config.run.action_timeout_ms)
             logger.info("Navigating to base URL", extra={"step": "navigate", "url": config.site.base_url})
             try:
                 page.goto(config.site.base_url, wait_until="networkidle", timeout=config.run.nav_timeout_ms)

--- a/src/browser.py
+++ b/src/browser.py
@@ -1,0 +1,56 @@
+"""Browser helper utilities for Playwright launches."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from playwright.sync_api import BrowserContext, Playwright
+else:  # pragma: no cover - runtime fallback for tests without Playwright
+    BrowserContext = object  # type: ignore[assignment]
+    Playwright = object  # type: ignore[assignment]
+
+from .config import Config
+
+
+def _accept_language_header(locale: str | None) -> str:
+    if not locale:
+        return "en-US,en;q=0.9"
+    lang = locale.split("-")[0]
+    if lang.lower() == "en" and locale.lower() != "en":
+        return f"{locale},en;q=0.9"
+    return f"{locale},{lang};q=0.9,en;q=0.8"
+
+
+def launch_user_context(playwright: Playwright, config: Config, *, headless: bool) -> BrowserContext:
+    """Launch the persistent Chromium context optimized for automation."""
+    launch_args: List[str] = [str(arg) for arg in config.run.chromium_launch_args]
+    locale = config.run.browser_locale
+    if locale and not any(arg.startswith("--lang=") for arg in launch_args):
+        launch_args.append(f"--lang={locale}")
+
+    launch_kwargs: Dict[str, object] = {
+        "user_data_dir": str(config.userdata_dir),
+        "headless": headless,
+    }
+    if locale:
+        launch_kwargs["locale"] = locale
+    if launch_args:
+        launch_kwargs["args"] = launch_args
+
+    context = playwright.chromium.launch_persistent_context(**launch_kwargs)
+    accept_language = config.run.accept_language or _accept_language_header(locale)
+    context.set_extra_http_headers({"Accept-Language": accept_language})
+    context.set_default_navigation_timeout(config.run.nav_timeout_ms)
+    context.set_default_timeout(config.run.action_timeout_ms)
+    if locale:
+        context.add_init_script(
+            """
+            (() => {
+                const locale = %r;
+                Object.defineProperty(navigator, 'language', { value: locale, configurable: true });
+                Object.defineProperty(navigator, 'languages', { value: [locale, 'en'], configurable: true });
+            })();
+            """
+            % locale
+        )
+    return context

--- a/src/signin.py
+++ b/src/signin.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError, sync_playwright
 
+from .browser import launch_user_context
 from .config import Config, load_config
 from .logging_setup import setup_logging
 from .notifier_email import EmailNotifier
@@ -62,13 +63,8 @@ def _attempt_checkin(
     context = None
     try:
         with sync_playwright() as playwright:
-            context = playwright.chromium.launch_persistent_context(
-                user_data_dir=str(config.userdata_dir),
-                headless=headless,
-            )
+            context = launch_user_context(playwright, config, headless=headless)
             page = context.new_page()
-            page.set_default_navigation_timeout(config.run.nav_timeout_ms)
-            page.set_default_timeout(config.run.action_timeout_ms)
             logger.info(
                 "Navigating to check-in page",
                 extra={"step": "navigate", "url": config.site.checkin_url, "attempt": attempt},

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.browser import launch_user_context
+from src.config import (
+    Config,
+    LoggingConfig,
+    NotifyConfig,
+    RunConfig,
+    ScheduleConfig,
+    SelectorConfig,
+    SiteConfig,
+    SMTPConfig,
+)
+
+
+class ContextStub:
+    def __init__(self) -> None:
+        self.extra_headers = None
+        self.nav_timeout = None
+        self.action_timeout = None
+        self.init_scripts = []
+
+    def set_extra_http_headers(self, headers):
+        self.extra_headers = headers
+
+    def set_default_navigation_timeout(self, value: int) -> None:
+        self.nav_timeout = value
+
+    def set_default_timeout(self, value: int) -> None:
+        self.action_timeout = value
+
+    def add_init_script(self, script: str) -> None:
+        self.init_scripts.append(script)
+
+
+class ChromiumStub:
+    def __init__(self, context: ContextStub) -> None:
+        self.context = context
+        self.launch_kwargs = None
+
+    def launch_persistent_context(self, **kwargs):
+        self.launch_kwargs = kwargs
+        return self.context
+
+
+class PlaywrightStub:
+    def __init__(self, chromium: ChromiumStub) -> None:
+        self.chromium = chromium
+
+
+def make_config(tmp_path: Path) -> Config:
+    smtp = SMTPConfig(
+        host="smtp.example.com",
+        port=465,
+        use_ssl=True,
+        recipients=("ops@example.com",),
+    )
+    return Config(
+        timezone="UTC",
+        schedule=ScheduleConfig(),
+        notify=NotifyConfig(enable_email=True, smtp=smtp),
+        run=RunConfig(
+            nav_timeout_ms=12345,
+            action_timeout_ms=6789,
+            chromium_launch_args=("--foo",),
+            browser_locale="en-US",
+        ),
+        selectors=SelectorConfig(),
+        site=SiteConfig(base_url="https://example.com", checkin_url="https://example.com"),
+        logging=LoggingConfig(log_file=tmp_path / "logs.jsonl"),
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        history_file=tmp_path / "data" / "history.csv",
+        screenshots_dir=tmp_path / "screenshots",
+        userdata_dir=tmp_path / "userdata",
+        meta_dir=tmp_path / "meta",
+    )
+
+
+def test_launch_user_context_configures_locale_and_headers(tmp_path: Path) -> None:
+    config = make_config(tmp_path)
+    context = ContextStub()
+    chromium = ChromiumStub(context)
+    playwright = PlaywrightStub(chromium)
+
+    result = launch_user_context(playwright, config, headless=True)
+
+    assert result is context
+    assert chromium.launch_kwargs["headless"] is True
+    assert chromium.launch_kwargs["locale"] == "en-US"
+    assert "--foo" in chromium.launch_kwargs["args"]
+    assert any(arg.startswith("--lang=en-US") for arg in chromium.launch_kwargs["args"])
+    assert context.extra_headers == {"Accept-Language": "en-US,en;q=0.9"}
+    assert context.nav_timeout == 12345
+    assert context.action_timeout == 6789
+    assert any("navigator" in script for script in context.init_scripts)
+
+
+def test_launch_user_context_respects_custom_accept_language(tmp_path: Path) -> None:
+    config = make_config(tmp_path)
+    config.run.accept_language = "en-GB,en;q=0.9"
+    context = ContextStub()
+    chromium = ChromiumStub(context)
+    playwright = PlaywrightStub(chromium)
+
+    launch_user_context(playwright, config, headless=False)
+
+    assert chromium.launch_kwargs["headless"] is False
+    assert context.extra_headers == {"Accept-Language": "en-GB,en;q=0.9"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,9 @@ max_retries = 5
 retry_backoff_seconds = [1.5, 3.0, 6.0]
 history_limit = 50
 screenshot_on_failure = false
+browser_locale = "en-GB"
+chromium_launch_args = ["--foo", "--lang=en-GB"]
+accept_language = "en-GB,en;q=0.7"
 
 [selectors]
 login_required = ["#login"]
@@ -68,6 +71,9 @@ def test_load_config_expands_paths(tmp_path: Path) -> None:
     assert config.notify.smtp.use_starttls is True
     assert config.notify.smtp.recipients == ("ops@example.com", "alerts@example.com")
     assert config.run.retry_backoff_seconds == (1.5, 3.0, 6.0)
+    assert config.run.browser_locale == "en-GB"
+    assert config.run.chromium_launch_args == ("--foo", "--lang=en-GB")
+    assert config.run.accept_language == "en-GB,en;q=0.7"
     assert config.selectors.login_required == ("#login",)
 
 


### PR DESCRIPTION
## Summary
- add a browser helper that applies optimized Chromium launch arguments and English locale defaults
- extend `RunConfig` with language, Accept-Language, and launch argument settings while documenting the new options
- update the authorization and automated sign-in flows to reuse the helper and cover the behavior with new tests

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f228803c8321a3d3708a0f4a9651